### PR TITLE
ENH: ELog and HutchELog

### DIFF
--- a/elog/__init__.py
+++ b/elog/__init__.py
@@ -1,3 +1,7 @@
+__all__ = ['ELog', 'HutchELog']
+
+from .elog import ELog, HutchELog
+
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/elog/elog.py
+++ b/elog/elog.py
@@ -146,6 +146,6 @@ class HutchELog(ELog):
             books.append('facility')
         else:
             raise ValueError("Must select either facility or experiment")
-        # Post 
+        # Post
         super().post(msg, run=run, tags=tags,
                      attachments=attachments, logbooks=books)

--- a/elog/elog.py
+++ b/elog/elog.py
@@ -1,0 +1,151 @@
+"""
+Front-facing API for PCDS Elog
+"""
+import logging
+
+from collections import namedtuple
+
+from .utils import facility_name
+from .pswww import PHPWebService
+
+logger = logging.getLogger(__name__)
+
+
+Attachment = namedtuple('Attachment', ('path', 'description'))
+
+
+class ELog:
+    """
+    Basic interface to ELog
+
+    Parameters
+    ----------
+    logbooks : dict
+        A mapping of aliases to logbook identifiers
+
+    user : str, optional
+        Username
+
+    pw : str, optional
+        Password, if this is left blank and a username is supplied the password
+        will be requested via prompt
+    """
+    def __init__(self, logbooks, user=None, pw=None):
+        self.logbooks = logbooks
+        self.service = PHPWebService(user=user, pw=pw)
+
+    def post(self, msg, run=None, tags=None, attachments=None, logbooks=None):
+        """
+        Post to the logbooks
+
+        Parameters
+        ----------
+        msg : str
+            Desired text of LogBook message
+
+        run : int, optional
+            Associate the post with a specific run
+
+        tags : list, optional
+            List of tags to add to the post
+
+        attachments : list, optional
+            These can either be entered as the path to each attachment or a
+            tuple of a path and description
+
+        logbooks : list, optional
+            Only post to a subset of the logbooks known by the client. If this
+            is left as None, all logbooks will be included.
+        """
+        logbooks = logbooks or self.logbooks.keys()
+        for alias in logbooks:
+            logger.info('Posting to %s logbook ...', alias)
+            # Grab the information from our logbook
+            try:
+                book_id = self.logbooks[alias]
+            except KeyError as exc:
+                logger.exception('Invalid logbook name %s', exc)
+            else:
+                # Post the information to selected id
+                self.service.post(msg, book_id,
+                                  run=run, tags=tags,
+                                  attachments=attachments)
+
+
+class HutchELog(ELog):
+    """
+    ELog client for LCLS instruments
+
+    This client will find the name of both the current experimental logbook as
+    well as the facility logbook for the instrument. Authentication can be done
+    in one of two ways; ws-auth if a username and/or password is supplied, or
+    kerberos if these keywords are left blank
+
+    Parameters
+    ----------
+    instrument : str
+        Three letter acronym for instrument
+
+    station : str, optional
+        Specify a sub-station of the instrument
+
+    user: str, optional
+        Username for ws-auth authentication
+
+    pw : str, optional
+        Password, if this is left blank and a username is supplied the password
+        will be requested via prompt
+    """
+    def __init__(self, instrument, station=None, user=None, pw=None):
+        self.instrument = instrument
+        self.station = station
+        # Load an empty service
+        logger.debug("Loading logbooks for %s", instrument)
+        super().__init__({}, user=user, pw=pw)
+        # Load the facilities logbook
+        f_id = facility_name(instrument)
+        self.logbooks['facility'] = self.service.get_facilities_logbook(f_id)
+        # Load the experiment logbook
+        exp_id = self.service.get_experiment_logbook(instrument,
+                                                     station=station)
+        self.logbooks['experiment'] = exp_id
+
+    def post(self, msg, run=None, tags=None, attachments=None,
+             experiment=True, facility=True):
+        """
+        Post to ELog
+
+        Parameters
+        ----------
+        msg: str
+            Body of message
+
+        run : int, optional
+            Associate the post with a specific run
+
+        tags : list, optional
+            List of tags to add to the post
+
+        attachments : list, optional
+            These can either be entered as the path to each attachment or a
+            tuple of a path and description
+
+        facility : bool, optional
+            Post to the facility logbook
+
+        experiment: bool, optional
+            Post to the experimental logbook
+        """
+        # If we want both logbooks we don't need to do anything special
+        if experiment and facility:
+            super().post(msg, run=run, tags=tags, attachments=attachments)
+        # Otherwise narrow our logbooks and post to this smaller subset
+        else:
+            books = list()
+            if experiment:
+                books.append('experiment')
+            if facility:
+                books.append('facility')
+            super().post(msg, run=run, tags=tags,
+                         attachments=attachments,
+                         logbooks=books)

--- a/elog/elog.py
+++ b/elog/elog.py
@@ -136,16 +136,16 @@ class HutchELog(ELog):
         experiment: bool, optional
             Post to the experimental logbook
         """
-        # If we want both logbooks we don't need to do anything special
+        books = list()
+        # Select our logbooks
         if experiment and facility:
-            super().post(msg, run=run, tags=tags, attachments=attachments)
-        # Otherwise narrow our logbooks and post to this smaller subset
+            pass
+        elif experiment:
+            books.append('experiment')
+        elif facility:
+            books.append('facility')
         else:
-            books = list()
-            if experiment:
-                books.append('experiment')
-            if facility:
-                books.append('facility')
-            super().post(msg, run=run, tags=tags,
-                         attachments=attachments,
-                         logbooks=books)
+            raise ValueError("Must select either facility or experiment")
+        # Post 
+        super().post(msg, run=run, tags=tags,
+                     attachments=attachments, logbooks=books)

--- a/elog/elog.py
+++ b/elog/elog.py
@@ -111,7 +111,7 @@ class HutchELog(ELog):
         self.logbooks['experiment'] = exp_id
 
     def post(self, msg, run=None, tags=None, attachments=None,
-             experiment=True, facility=True):
+             experiment=True, facility=False):
         """
         Post to ELog
 

--- a/elog/pswww.py
+++ b/elog/pswww.py
@@ -188,7 +188,7 @@ class PHPWebService:
             These can either be entered as the path to each attachment or a
             tuple of a path and description
         """
-        logger.info("Posting to Logbook ID: %s", logbook_id)
+        logger.debug("Posting to Logbook ID: %s", logbook_id)
         # Basic post information
         post = {'author_account': self._user,
                 'message_text': msg,

--- a/elog/utils.py
+++ b/elog/utils.py
@@ -1,0 +1,8 @@
+"""
+Utility functions for PCDS ELog
+"""
+
+
+def facility_name(hutch):
+    """Return the facility name for an instrument"""
+    return '{} Instrument'.format(hutch.upper())

--- a/tests/test_elog.py
+++ b/tests/test_elog.py
@@ -34,12 +34,12 @@ def test_hutchelog_init(mockelog):
 
 
 def test_elog_post(mockelog):
-    mockelog.post('Both logbooks', tags='first')
+    mockelog.post('Both logbooks', tags='first', facility=True)
     assert len(mockelog.service.posts) == 2
-    mockelog.post('Facility', experiment=False)
+    mockelog.post('Facility', experiment=False, facility=True)
     assert len(mockelog.service.posts) == 3
     assert mockelog.service.posts[-1][0][1] == '0'
-    mockelog.post('Experiment', facility=False)
+    mockelog.post('Experiment')
     assert len(mockelog.service.posts) == 4
     assert mockelog.service.posts[-1][0][1] == '1'
     with pytest.raises(ValueError):

--- a/tests/test_elog.py
+++ b/tests/test_elog.py
@@ -42,3 +42,5 @@ def test_elog_post(mockelog):
     mockelog.post('Experiment', facility=False)
     assert len(mockelog.service.posts) == 4
     assert mockelog.service.posts[-1][0][1] == '1'
+    with pytest.raises(ValueError):
+        mockelog.post('Failure', experiment=False, facility=False)

--- a/tests/test_elog.py
+++ b/tests/test_elog.py
@@ -1,0 +1,44 @@
+import pytest
+
+import elog.elog
+
+
+@pytest.fixture(scope='module')
+def mockelog():
+
+    # A very basic mock Webservice
+    class WebService:
+
+        def __init__(self, *args, **kwargs):
+            self.posts = list()
+
+        def post(self, *args, **kwargs):
+            self.posts.append((args, kwargs))
+
+        def get_facilities_logbook(self, instrument):
+            return '0'
+
+        def get_experiment_logbook(self, instrument, station=None):
+            return '1'
+
+    # Store value
+    orig_web = elog.elog.PHPWebService
+    elog.elog.PHPWebService = WebService
+    yield elog.elog.HutchELog('TST')
+    elog.elog.PHPWebService = orig_web
+
+
+def test_hutchelog_init(mockelog):
+    assert mockelog.logbooks['facility'] == '0'
+    assert mockelog.logbooks['experiment'] == '1'
+
+
+def test_elog_post(mockelog):
+    mockelog.post('Both logbooks', tags='first')
+    assert len(mockelog.service.posts) == 2
+    mockelog.post('Facility', experiment=False)
+    assert len(mockelog.service.posts) == 3
+    assert mockelog.service.posts[-1][0][1] == '0'
+    mockelog.post('Experiment', facility=False)
+    assert len(mockelog.service.posts) == 4
+    assert mockelog.service.posts[-1][0][1] == '1'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The front-facing API for the ELog. Most of the users will just load the `HutchELog`. This handles finding the facilities and current experiment logbooks and storing their identifies. Operators can then choose to post to both, or either one individually by using boolean keywords accessible on `.post`.

```python
elog = HutchELog('XPP')
elog.post('Only a message for the facility', experiment=False)
```

If more exotic combinations of ELogs are required. You can manually add logbooks to the `.logbooks` dictionary, or use the base `ELog` class.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Covered with a mock webservice underneath

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings

