### PR TITLE
FIX: Typo in URL construction for optional station kwarg

### DIFF
--- a/elog/pswww.py
+++ b/elog/pswww.py
@@ -153,7 +153,7 @@ class PHPWebService:
         url = '{url}/LogBook/RequestCurrentExperiment.php?instr={instr}'\
               ''.format(url=self._url, instr=instrument)
         if station:
-            url += '%station={}'.format(station)
+            url += '&station={}'.format(station)
         # Make request to WebService
         result = requests.get(url, **self._auth)
         # Invalid HTTP code


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
There was a typo in how the URL was constructed when connecting to a non-standard station. This was noticed because the secondary CXI monitor runs at a different experimental station than the main `cxi-daq` machine.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #11 
