### PR TITLE
TST: Changing Testing Suite Defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ script:
   # this case
   - |
     if [[ $TRAVIS_PULL_REQUEST == false ]]; then
-      coverage run run_tests.py --user $TEST_USER --pw $TEST_PW --no-kerberos
+      coverage run run_tests.py --user $TEST_USER --pw $TEST_PW
     else
-      coverage run run_tests.py --no-kerberos
+      coverage run run_tests.py
     fi
   - coverage report -m
   - flake8 elog

--- a/README.md
+++ b/README.md
@@ -74,13 +74,12 @@ authentication methods are shown below:
 ```
 
 ## Test Suite
-The automated testing package will attempt to actually interface with the web
-server using `kerberos` authentication. If you do not want to run these tests
-you can use the keyword `no-kerberos` to skip the relevant tests and run with a
-different username and password.
+The automated testing package has multiple options to attempt to interface with
+the actual web service. If you want to run these tests you can either
+authenticate with `--user` and/or you can use the keyword `kerberos`.
 
 ```shell
-python run_tests --user my_user --pw my_pw --no-kerberos
+python run_tests.py --user my_user --pw my_pw --kerberos
 ```
 
 There are also tests that post to the web service but these are disabled by

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ def pytest_addoption(parser):
                      help='Username for ws-auth authentication')
     parser.addoption('--pw', action='store', default=None,
                      help='Password user for ws-auth authentication')
-    parser.addoption('--no-kerberos', action='store_true', default=False,
+    parser.addoption('--kerberos', action='store_true', default=False,
                      help='Whether or not to attempt Kerberos authentication')
     parser.addoption('--post', action='store_true', default=False,
                      help='Whether to include tests that post to the ELog')
@@ -20,7 +20,7 @@ def pytest_generate_tests(metafunc):
     services = []
     ids = []
     # Create a Kerberos authentication
-    if not metafunc.config.option.no_kerberos:
+    if metafunc.config.option.kerberos:
         services.append(PHPWebService())
         ids.append('ws-kerb')
 


### PR DESCRIPTION
Changes the testing suite default to not attempt the kerberos tests. In order to make the command line option more sensible in this schema it has been changed from `no-kerberos` to `kerberos`.
