### PR TITLE
MNT: remove codecov after security breach

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,4 +2,3 @@ sphinx
 sphinx_rtd_theme
 pytest
 flake8
-codecov


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove codecov. We aren't using it and they had a security breach