### PR TITLE
ENH: Fix instrument log names for L2SI hutches

### DIFF
--- a/elog/utils.py
+++ b/elog/utils.py
@@ -5,4 +5,6 @@ Utility functions for PCDS ELog
 
 def facility_name(hutch):
     """Return the facility name for an instrument"""
+    if hutch in ['tmo', 'rix', 'txi', 'TMO', 'RIX', 'TXI']:
+        return '{}_Instrument'.format(hutch.lower())
     return '{}_Instrument'.format(hutch.upper())

--- a/elog/utils.py
+++ b/elog/utils.py
@@ -5,6 +5,9 @@ Utility functions for PCDS ELog
 
 def facility_name(hutch):
     """Return the facility name for an instrument"""
-    if hutch in ['tmo', 'rix', 'txi', 'TMO', 'RIX', 'TXI']:
-        return '{}_Instrument'.format(hutch.lower())
-    return '{}_Instrument'.format(hutch.upper())
+    if hutch in [
+        'dia', 'mfx', 'mec', 'cxi', 'xcs', 'xpp', 'sxr', 'amo',
+        'DIA', 'MFX', 'MEC', 'CXI', 'XCS', 'XPP', 'SXR', 'AMO',
+    ]:
+        return '{}_Instrument'.format(hutch.upper())
+    return '{}_Instrument'.format(hutch.lower())


### PR DESCRIPTION
## Description
Return the hutch name in lowercase for new hutches when figuring out the instrument elog name

## Motivation and Context
The instrument elog names for new hutches are of the form 'tmo_Instrument' as opposed to 'CXI_Instrument'

## How Has This Been Tested?
Interactively.

## Where Has This Been Documented?
🤷‍♂️ 
