### PR TITLE
Add support for Dev elog, bluesky API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+    -   id: no-commit-to-branch
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-ast
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: check-xml
+    -   id: check-yaml
+        exclude: '^(conda-recipe/meta.yaml)$'
+    -   id: debug-statements
+
+-   repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.8.4
+    hooks:
+    -   id: flake8
+
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.6.4
+    hooks:
+    -   id: isort

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ env:
 
 jobs:
   allow_failures:
-    - name: "Python 3.6 - PIP"
-    - name: "Docs Build (Python 3.6)"
+    - name: "Python - PIP"
+    - name: "Docs Build"
     - name: "Docs Upload"
 
 import:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python >=3.5
     - requests
     - krtc
+    - ophyd
 
 test:
   imports:
@@ -27,4 +28,4 @@ test:
 about:
   home: https://github.com/pcdshub/elog
   license: SLAC Open License
-  summary: Python API for interfacing with LCLS ELog 
+  summary: Python API for interfacing with LCLS ELog

--- a/elog/elog.py
+++ b/elog/elog.py
@@ -1,14 +1,13 @@
 """
 Front-facing API for PCDS Elog
 """
-import os
 import logging
-from configparser import NoOptionError, ConfigParser
-
+import os
 from collections import namedtuple
+from configparser import ConfigParser, NoOptionError
 
-from .utils import facility_name, get_primary_elog, register_elog
 from .pswww import PHPWebService
+from .utils import facility_name, get_primary_elog, register_elog
 
 logger = logging.getLogger(__name__)
 
@@ -35,9 +34,11 @@ class ELog:
     base_url : str, optional
         Point to a different server; perhaps a test server.
     """
-    def __init__(self, logbooks, user=None, pw=None, base_url=None):
+    def __init__(self, logbooks, user=None, pw=None, base_url=None, dev=False):
         self.logbooks = logbooks
-        self.service = PHPWebService(user=user, pw=pw, base_url=base_url)
+        self.service = PHPWebService(user=user, pw=pw,
+                                     base_url=base_url, dev=dev
+                                     )
 
     def post(self, msg, run=None, tags=None,
              attachments=None, logbooks=None, title=None):
@@ -117,12 +118,12 @@ class HutchELog(ELog):
     """
 
     def __init__(self, instrument, station=None, user=None, pw=None,
-                 base_url=None, primary=None):
+                 base_url=None, primary=None, dev=False):
         self.instrument = instrument
         self.station = station
         # Load an empty service
         logger.debug("Loading logbooks for %s", instrument)
-        super().__init__({}, user=user, pw=pw, base_url=base_url)
+        super().__init__({}, user=user, pw=pw, base_url=base_url, dev=dev)
         # Load the facilities logbook
         f_id = facility_name(instrument)
         self.logbooks['facility'] = self.service.get_facilities_logbook(f_id)

--- a/elog/elog.py
+++ b/elog/elog.py
@@ -92,6 +92,15 @@ class HutchELog(ELog):
     in one of two ways; ws-auth if a username and/or password is supplied, or
     kerberos if these keywords are left blank
 
+    Usage:
+
+        .. code-block:: python
+
+            el = HutchELog('XPP')
+
+            # Only 'tsd' currently works (2/22)
+            el_dev = HutchELog('tsd', dev=True)
+
     Parameters
     ----------
     instrument : str
@@ -118,7 +127,8 @@ class HutchELog(ELog):
     """
 
     def __init__(self, instrument, station=None, user=None, pw=None,
-                 base_url=None, primary=None, dev=False):
+                 base_url=None, primary=None, dev=False,
+                 enable_run_posts=False):
         self.instrument = instrument
         self.station = station
         # Load an empty service
@@ -132,6 +142,8 @@ class HutchELog(ELog):
                                                      station=station)
         self.logbooks['experiment'] = exp_id
         register_elog(self, primary=primary)
+
+        self.enable_run_posts = enable_run_posts
 
     def post(self, msg, run=None, tags=None, attachments=None,
              experiment=True, facility=False, title=None):

--- a/elog/elog.py
+++ b/elog/elog.py
@@ -145,6 +145,7 @@ class HutchELog(ELog):
         self.logbooks['experiment'] = exp_id
         register_elog(self, primary=primary)
 
+        # Switch for ELog posting callback in pcdshub/nabs
         self.enable_run_posts = enable_run_posts
 
     def post(self, msg, run=None, tags=None, attachments=None,

--- a/elog/elog.py
+++ b/elog/elog.py
@@ -6,6 +6,8 @@ import os
 from collections import namedtuple
 from configparser import ConfigParser, NoOptionError
 
+from ophyd.status import StatusBase
+
 from .pswww import PHPWebService
 from .utils import facility_name, get_primary_elog, register_elog
 
@@ -238,3 +240,12 @@ class HutchELog(ELog):
         ValueError.
         """
         return get_primary_elog()
+
+    def set(self, *args, **kwargs):
+        """ Pass through method to post for Bluesky API compatibility """
+        self.post(*args, **kwargs)
+
+        # set message requrires a status object to be returned.
+        # another message could possibly be used, but this seemed simplest
+        status = StatusBase(done=True, success=True)
+        return status

--- a/elog/pswww.py
+++ b/elog/pswww.py
@@ -40,11 +40,13 @@ class PHPWebService:
         self._auth = None
         self._base_url = base_url if base_url else self.base_url
         self.url = None
-        if dev:
-            self._lgbk = 'devlgbk'
-        else:
-            self._lgbk = 'lgbk'
+
         self.authenticate(user=user, pw=pw)
+
+        if dev:
+            self._lgbk_base_url = self._url + '/devlgbk'
+        else:
+            self._lgbk_base_url = self._url + '/lgbk'
 
     def authenticate(self, user=None, pw=None):
         """
@@ -111,7 +113,7 @@ class PHPWebService:
             web.get_facilities_logbook('CXI Instrument')
         """
         # Format correct URL
-        url = (self._url + f'/{self._lgbk}/lgbk/' + instrument + '/ws/info')
+        url = (self._lgbk_base_url + '/lgbk/' + instrument + '/ws/info')
         # Make request to WebService
         result = requests.get(url, **self._auth)
         # Invalid HTTP code
@@ -156,9 +158,11 @@ class PHPWebService:
 
         logger.debug("Requesting current experiment for %s", instrument)
         # Format correct URL
-        url = '{url}/{lgbk}/lgbk/ws/activeexperiment_for_instrument_station' \
-              '?instrument_name={instrument}' \
-              ''.format(url=self._url, lgbk=self._lgbk, instrument=instrument)
+        url = (
+            f'{self._lgbk_base_url}/lgbk/ws/'
+            'activeexperiment_for_instrument_station'
+            f'?instrument_name={instrument}'
+        )
         if station:
             url += '&station={}'.format(station)
         # Make request to WebService
@@ -230,8 +234,8 @@ class PHPWebService:
                     mimetypes.guess_type(filename)[0])))
 
         # Make request to web service
-        url = self._url + f"/{self._lgbk}/lgbk/" + \
-            logbook_id + "/ws/new_elog_entry"
+        url = self._lgbk_base_url + "/lgbk/" \
+            + logbook_id + "/ws/new_elog_entry"
         if files:
             result = requests.post(url, data=post, files=files, **self._auth)
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-krtc
+git+https://github.com/slaclab/krtc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 git+https://github.com/slaclab/krtc
+ophyd

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(name='elog',
       license='BSD',
       author='SLAC National Accelerator Laboratory',
       packages=find_packages(),
-      install_requires=requirements,
       description='Utilities for posting to LCLS Experimental ELog',
       scripts=['scripts/LogBookPost.py']
       )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
+from setuptools import find_packages, setup
+
 import versioneer
-from setuptools import setup, find_packages
+
+with open('requirements.txt') as f:
+    requirements = f.read().split()
 
 setup(name='elog',
       version=versioneer.get_version(),
@@ -7,6 +11,7 @@ setup(name='elog',
       license='BSD',
       author='SLAC National Accelerator Laboratory',
       packages=find_packages(),
+      install_requires=requirements,
       description='Utilities for posting to LCLS Experimental ELog',
       scripts=['scripts/LogBookPost.py']
       )

--- a/tests/test_elog.py
+++ b/tests/test_elog.py
@@ -79,7 +79,7 @@ def test_elog_post(mockelog):
 def test_elog_set(mockelog):
     msg = 'set method for post'
     st = mockelog.set(msg)
-    time.sleep(0.1)  # needed to allow status to resolve
+    st.wait(timeout=0.1)
     assert len(mockelog.service.posts) == 1
     assert mockelog.service.posts[-1][0][0] == msg
     assert st.done and st.success


### PR DESCRIPTION
## Description

- Adds support for connecting to the dev logbook
- Adds hooks to submit posts through the Bluesky message protocol, via the `set()` method


## Motivation and Context
[Jira ticket](https://jira.slac.stanford.edu/browse/LCLSPC-120)

## How Has This Been Tested?
Interactively, one test added to suite.  

## Where Has This Been Documented?
Docstrings, though additional documentation will be probably be necessary to teach users how to use these features

