### PR TITLE
BLD/FIX: lcls-krtc is on pypi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
-lcls-krtc @ git+https://github.com/slaclab/krtc@master
+lcls-krtc
 ophyd


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* lcls-krtc is on pypi

## Motivation and Context
Tagged build is failing to upload to PyPI due to the git ref here
